### PR TITLE
fix: login error

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -26,7 +26,7 @@ module Api
 
       def sign_in(user)
         # 如果使用者已經登入就不做事
-        if warden.user('user') == user
+        if warden.user == user
           true
         else
           warden.set_user(user)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -19,6 +19,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
              headers: :any,
-             methods: %i[get post put patch delete options head]
+             methods: %i[get post put patch delete options head],
+             credentials: true
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-Rails.application.config.session_store :cookie_store, {
-  key: '_taverneer',
-  domain: :all,
-  tld_length: 2
-}

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -9,3 +9,9 @@ end
 Warden::Manager.serialize_from_session do |id|
   User.find(id)
 end
+
+module Warden::Mixins::Common
+  def request
+    @request ||= ActionDispatch::Request.new(env)
+  end
+end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -2,16 +2,18 @@
 
 Warden::Strategies.add(:password, Authentication::PasswordStrategy)
 
-Warden::Manager.serialize_into_session do |user|
-  user.id
-end
+Warden::Manager.serialize_into_session(&:id)
 
 Warden::Manager.serialize_from_session do |id|
   User.find(id)
 end
 
-module Warden::Mixins::Common
-  def request
-    @request ||= ActionDispatch::Request.new(env)
+module Warden
+  module Mixins
+    module Common
+      def request
+        @request ||= ActionDispatch::Request.new(env)
+      end
+    end
   end
 end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,3 +1,11 @@
 # frozen_string_literal: true
 
 Warden::Strategies.add(:password, Authentication::PasswordStrategy)
+
+Warden::Manager.serialize_into_session do |user|
+  user.id
+end
+
+Warden::Manager.serialize_from_session do |id|
+  User.find(id)
+end

--- a/lib/authentication/password_strategy.rb
+++ b/lib/authentication/password_strategy.rb
@@ -36,11 +36,7 @@ module Authentication
     end
 
     def params_auth_hash
-      if Rails.env.test?
-        params['user']
-      else
-        @env["action_dispatch.request.parameters"]['user']
-      end
+      params['user']
     end
 
     def password

--- a/lib/authentication/password_strategy.rb
+++ b/lib/authentication/password_strategy.rb
@@ -36,7 +36,11 @@ module Authentication
     end
 
     def params_auth_hash
-      params['user']
+      if Rails.env.test?
+        params['user']
+      else
+        @env["action_dispatch.request.parameters"]['user']
+      end
     end
 
     def password

--- a/spec/requests/api/v1/sessions_controller_spec.rb
+++ b/spec/requests/api/v1/sessions_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Api::V1::SessionsController', type: :request do
 
       it 'stores user in session' do
         subject
-        expect(session['warden.user.default.key']).to eq(user)
+        expect(session['warden.user.default.key']).to eq(user.id)
       end
     end
 


### PR DESCRIPTION
1. 前端要做 cross-origin set cookie 的話，需要 credentials: true 的 attribute, [ref](https://scar.tw/article/2019/01/22/cors-ajax-and-cookie-request/)，但同時 server 在 cors 這邊也需要設定
2. Initializers 裡面的 session 部分重複設定在 application.rb 裡面了，移除掉檔案這邊的 code
3. 原本使用前端測試，發現在 strategy 裡面拿不到 request，原來是因為在 Rails 裡面跟 warden 裡面的 request 是不同的 class，參考 [devise 的方式](https://github.com/heartcombo/devise/blob/main/lib/devise/rails/warden_compat.rb#L3-L15)去 overwrite warden 的設定