### PR TITLE
feat: adjust current user api to add is_admin property

### DIFF
--- a/app/controllers/api/v1/current_user_controller.rb
+++ b/app/controllers/api/v1/current_user_controller.rb
@@ -5,7 +5,7 @@ module Api
     class CurrentUserController < ApplicationController
       def index
         if current_user
-          respond_with_json(status: :ok, user: { name: current_user.name })
+          respond_with_json(status: :ok, user: { name: current_user.name, is_admin: current_user.is_admin? })
         else
           respond_with_json(status: :not_found, message: 'Not Found')
         end

--- a/spec/requests/api/v1/current_user_controller_spec.rb
+++ b/spec/requests/api/v1/current_user_controller_spec.rb
@@ -11,13 +11,28 @@ RSpec.describe 'Api::V1::CurrentUserController', type: :request do
         sign_in(user)
       end
 
-      it 'gets ok response' do
-        subject
-        expect(response).to have_http_status(:ok)
-        expect(json_body).to match({
-                                     status: 'ok',
-                                     user: { name: 'qoosuperman' }
-                                   })
+      context 'when user is not admin' do
+        it 'gets ok response and is_admin: false' do
+          subject
+          expect(response).to have_http_status(:ok)
+          expect(json_body).to match({
+                                       status: 'ok',
+                                       user: { name: 'qoosuperman', is_admin: false }
+                                     })
+        end
+      end
+
+      context 'when user is admin' do
+        let(:user) { create(:user, :admin, name: 'qoosuperman') }
+
+        it 'gets ok response and is_admin: true' do
+          subject
+          expect(response).to have_http_status(:ok)
+          expect(json_body).to match({
+                                       status: 'ok',
+                                       user: { name: 'qoosuperman', is_admin: true }
+                                     })
+        end
       end
     end
 

--- a/spec/requests/api/v1/current_user_controller_spec.rb
+++ b/spec/requests/api/v1/current_user_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Api::V1::CurrentUserController', type: :request do
 
     context 'when already logged in' do
       before do
-        allow_any_instance_of(Warden::SessionSerializer).to receive(:fetch).and_return(user)
+        sign_in(user)
       end
 
       it 'gets ok response' do

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module RequestHelper
+  def sign_in(user)
+    allow_any_instance_of(Warden::SessionSerializer).to receive(:fetch).and_return(user)
+  end
+
   def json_body
     JSON.parse(response.body, symbolize_names: true)
   end


### PR DESCRIPTION
### Motivation / Background

frontend need an API to check if user is an admin

### Detail

original response:
```ruby
respond_with_json(status: :ok, user: { name: current_user.name})
```
new response:
```ruby
respond_with_json(status: :ok, user: { name: current_user.name, is_admin: current_user.is_admin? })
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] CI is passing.
